### PR TITLE
chore: align secret engine path

### DIFF
--- a/chart/product-traceability-foss-backend/values-dev.yaml
+++ b/chart/product-traceability-foss-backend/values-dev.yaml
@@ -21,4 +21,4 @@ ingress:
       secretName: tls-secret
 
 mailserver:
-  password: <path:traceability-foss-backend/data/dev#mailserverPassword>
+  password: <path:traceability-foss/data/dev#mailserverPassword>

--- a/chart/product-traceability-foss-backend/values-int.yaml
+++ b/chart/product-traceability-foss-backend/values-int.yaml
@@ -21,4 +21,4 @@ ingress:
       secretName: tls-secret
 
 mailserver:
-  password: <path:traceability-foss-backend/data/int#mailserverPassword>
+  password: <path:traceability-foss/data/int#mailserverPassword>


### PR DESCRIPTION
The DevSecOps team is aligning naming on all our managed resources, which makes it easier for us to manage it via terraform for example. We usually only create one secret engine per team in vault and also name it after the team instead of creating one secret engine per repository.
Is it ok for you to adjust the path to the secret engine? The login policies are all adjusted accordingly, so that you will have access to the secret engine. All existing secrets have been migrated. 
If there are any questions or problems, feel free to reach out via MS Teams