### PR TITLE
[TRACEFOSS-436] Add license header

### DIFF
--- a/scripts/LICENSE_HEADER
+++ b/scripts/LICENSE_HEADER
@@ -1,0 +1,16 @@
+Copyright (c) 2021,2022 Contributors to the CatenaX (ng) GitHub Organisation
+
+See the NOTICE file(s) distributed with this work for additional
+information regarding copyright ownership.
+
+This program and the accompanying materials are made available under the
+terms of the Apache License, Version 2.0 which is available at
+https://www.apache.org/licenses/LICENSE-2.0.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations
+under the License.
+
+SPDX-License-Identifier: Apache-2.0

--- a/scripts/add-license-header.js
+++ b/scripts/add-license-header.js
@@ -1,0 +1,162 @@
+/********************************************************************************
+ * Copyright (c) 2021,2022 Contributors to the CatenaX (ng) GitHub Organisation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+const fs = require('fs');
+const path = require('path');
+
+const getArg = argName => {
+  const argPrefix = `--${argName}=`;
+
+  for (const arg of process.argv) {
+    if (arg.startsWith(argPrefix) && arg.length > argPrefix.length) {
+      return arg.substring(argPrefix.length);
+    }
+  }
+
+  throw new Error('Cannot find arg with prefix ' + argPrefix);
+};
+
+const licenseHeader = fs.readFileSync(path.resolve(__dirname, 'LICENSE_HEADER'), 'utf8').trim();
+const srcPath = getArg('src');
+
+const LICENSE_COMMENT_WIDTH = 80;
+
+const buildAddComment =
+  ({ openComment, closeComment, trimLicense, printLicense = () => licenseHeader }) =>
+  content => {
+    const firstHtmlCommentStarts = content.indexOf(openComment());
+    const firstHtmlCommentsEnd =
+      firstHtmlCommentStarts > -1 ? content.indexOf(closeComment().trim(), firstHtmlCommentStarts) : -1;
+    const hasAnyComment =
+      firstHtmlCommentStarts > -1 &&
+      (firstHtmlCommentStarts === 0 || !content.substring(0, firstHtmlCommentStarts).trim());
+
+    const prependNewLicenseComment = (fileContent = content) =>
+      openComment(LICENSE_COMMENT_WIDTH) +
+      '\n' +
+      printLicense() +
+      '\n' +
+      closeComment(LICENSE_COMMENT_WIDTH) +
+      '\n\n' +
+      fileContent;
+
+    if (!hasAnyComment) {
+      return prependNewLicenseComment();
+    } else {
+      if (firstHtmlCommentsEnd === -1) {
+        throw new Error(`Cannot check invalid comment, there is no "${closeComment}" close comment`);
+      }
+      const maybeLicense = trimLicense(
+        content.substring(firstHtmlCommentStarts + openComment().length, firstHtmlCommentsEnd),
+      );
+
+      if (maybeLicense !== licenseHeader) {
+        const endOfLicenseHeader = content.indexOf('\n', firstHtmlCommentsEnd);
+        return prependNewLicenseComment(content.substring(endOfLicenseHeader + 2));
+      }
+    }
+
+    return content;
+  };
+
+const addHtmlComment = buildAddComment({
+  openComment: _ => '<!--',
+  closeComment: _ => '-->',
+  trimLicense: comment =>
+    comment
+      .split('\n')
+      .map(line => line.trimEnd())
+      .join('\n')
+      .trim(),
+});
+
+const addYmlLikeComment = buildAddComment({
+	openComment: (longestLine = 1) => new Array(longestLine).fill('#').join(''),
+	closeComment: (longestLine = 1) => new Array(longestLine).fill('#').join(''),
+	trimLicense: comment =>
+	  comment
+		.split('\n')
+		.map(line => line.replace(/^\s*\#\s?/, '').trimEnd())
+		.join('\n')
+		.trim(),
+	printLicense: () =>
+	  licenseHeader
+		.split('\n')
+		.map(line => (line.trim() ? `# ${line}` : '#'))
+		.join('\n'),
+  });
+
+const addJsLikeComment = buildAddComment({
+  openComment: (longestLine = 1) => '/' + new Array(longestLine).fill('*').join(''),
+  closeComment: (longestLine = 1) => ' ' + new Array(longestLine).fill('*').join('') + '/',
+  trimLicense: comment =>
+    comment
+      .split('\n')
+      .map(line => line.replace(/^\s*\*\s?/, '').trimEnd())
+      .join('\n')
+      .trim(),
+  printLicense: () =>
+    licenseHeader
+      .split('\n')
+      .map(line => (line.trim() ? ` * ${line}` : ' *'))
+      .join('\n'),
+});
+
+const supportedExtensions = {
+  html: addHtmlComment,
+  java: addJsLikeComment,
+  groovy: addJsLikeComment,
+  yml: addYmlLikeComment,
+  js: addJsLikeComment,
+  ts: addJsLikeComment,
+  scss: addJsLikeComment,
+};
+
+const ensureThatCommentExists = filePath => {
+  for (const ext in supportedExtensions) {
+    if (filePath.endsWith('.' + ext)) {
+      const fileContent = fs.readFileSync(filePath, 'utf8');
+      try {
+        const transformedContent = supportedExtensions[ext](fileContent);
+        fs.writeFileSync(filePath, transformedContent, 'utf8');
+      } catch (err) {
+        throw new Error(`Cannot transform ${filePath}`, { cause: err });
+      }
+    }
+  }
+};
+
+const lookupForFiles = src =>
+  fs.readdirSync(src, { withFileTypes: true }).map(dirent => ({
+    isDir: dirent.isDirectory(),
+    path: path.resolve(src, dirent.name),
+  }));
+
+const filesToIterate = lookupForFiles(srcPath);
+
+while (filesToIterate.length > 0) {
+  const fileToIterate = filesToIterate.pop();
+  if (fileToIterate.isDir) {
+    lookupForFiles(fileToIterate.path).forEach(file => {
+      filesToIterate.push(file);
+    });
+  } else {
+    ensureThatCommentExists(fileToIterate.path);
+  }
+}

--- a/src/integration/groovy/net/catenax/traceability/IntegrationSpec.groovy
+++ b/src/integration/groovy/net/catenax/traceability/IntegrationSpec.groovy
@@ -1,3 +1,22 @@
+/********************************************************************************
+ * Copyright (c) 2021,2022 Contributors to the CatenaX (ng) GitHub Organisation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 package net.catenax.traceability
 
 import com.xebialabs.restito.server.StubServer

--- a/src/integration/groovy/net/catenax/traceability/assets/infrastructure/adapters/email/EmailServiceIT.groovy
+++ b/src/integration/groovy/net/catenax/traceability/assets/infrastructure/adapters/email/EmailServiceIT.groovy
@@ -1,3 +1,22 @@
+/********************************************************************************
+ * Copyright (c) 2021,2022 Contributors to the CatenaX (ng) GitHub Organisation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 package net.catenax.traceability.assets.infrastructure.adapters.email
 
 import net.catenax.traceability.IntegrationSpec

--- a/src/integration/groovy/net/catenax/traceability/assets/infrastructure/adapters/rest/AssetsControllerIT.groovy
+++ b/src/integration/groovy/net/catenax/traceability/assets/infrastructure/adapters/rest/AssetsControllerIT.groovy
@@ -1,3 +1,22 @@
+/********************************************************************************
+ * Copyright (c) 2021,2022 Contributors to the CatenaX (ng) GitHub Organisation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 package net.catenax.traceability.assets.infrastructure.adapters.rest
 
 import net.catenax.traceability.IntegrationSpec

--- a/src/integration/groovy/net/catenax/traceability/assets/infrastructure/adapters/rest/DashboardControllerIT.groovy
+++ b/src/integration/groovy/net/catenax/traceability/assets/infrastructure/adapters/rest/DashboardControllerIT.groovy
@@ -1,3 +1,22 @@
+/********************************************************************************
+ * Copyright (c) 2021,2022 Contributors to the CatenaX (ng) GitHub Organisation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 package net.catenax.traceability.assets.infrastructure.adapters.rest
 
 import net.catenax.traceability.IntegrationSpec

--- a/src/integration/groovy/net/catenax/traceability/common/config/MailboxConfig.groovy
+++ b/src/integration/groovy/net/catenax/traceability/common/config/MailboxConfig.groovy
@@ -1,3 +1,22 @@
+/********************************************************************************
+ * Copyright (c) 2021,2022 Contributors to the CatenaX (ng) GitHub Organisation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 package net.catenax.traceability.common.config
 
 import com.icegreen.greenmail.spring.GreenMailBean

--- a/src/integration/groovy/net/catenax/traceability/common/config/OAuth2Config.groovy
+++ b/src/integration/groovy/net/catenax/traceability/common/config/OAuth2Config.groovy
@@ -1,3 +1,22 @@
+/********************************************************************************
+ * Copyright (c) 2021,2022 Contributors to the CatenaX (ng) GitHub Organisation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 package net.catenax.traceability.common.config
 
 

--- a/src/integration/groovy/net/catenax/traceability/common/config/RestitoConfig.groovy
+++ b/src/integration/groovy/net/catenax/traceability/common/config/RestitoConfig.groovy
@@ -1,3 +1,22 @@
+/********************************************************************************
+ * Copyright (c) 2021,2022 Contributors to the CatenaX (ng) GitHub Organisation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 package net.catenax.traceability.common.config
 
 import com.xebialabs.restito.server.StubServer

--- a/src/integration/groovy/net/catenax/traceability/common/config/SecurityTestConfig.groovy
+++ b/src/integration/groovy/net/catenax/traceability/common/config/SecurityTestConfig.groovy
@@ -1,3 +1,22 @@
+/********************************************************************************
+ * Copyright (c) 2021,2022 Contributors to the CatenaX (ng) GitHub Organisation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 package net.catenax.traceability.common.config
 
 import org.springframework.boot.test.context.TestConfiguration

--- a/src/integration/groovy/net/catenax/traceability/common/support/BpnApiSupport.groovy
+++ b/src/integration/groovy/net/catenax/traceability/common/support/BpnApiSupport.groovy
@@ -1,3 +1,22 @@
+/********************************************************************************
+ * Copyright (c) 2021,2022 Contributors to the CatenaX (ng) GitHub Organisation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 package net.catenax.traceability.common.support
 
 import com.xebialabs.restito.semantics.Action

--- a/src/integration/groovy/net/catenax/traceability/common/support/IrsApiSupport.groovy
+++ b/src/integration/groovy/net/catenax/traceability/common/support/IrsApiSupport.groovy
@@ -1,3 +1,22 @@
+/********************************************************************************
+ * Copyright (c) 2021,2022 Contributors to the CatenaX (ng) GitHub Organisation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 package net.catenax.traceability.common.support
 
 import com.xebialabs.restito.semantics.Action

--- a/src/integration/groovy/net/catenax/traceability/common/support/KeycloakApiSupport.groovy
+++ b/src/integration/groovy/net/catenax/traceability/common/support/KeycloakApiSupport.groovy
@@ -1,3 +1,22 @@
+/********************************************************************************
+ * Copyright (c) 2021,2022 Contributors to the CatenaX (ng) GitHub Organisation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 package net.catenax.traceability.common.support
 
 import com.xebialabs.restito.semantics.Action

--- a/src/integration/groovy/net/catenax/traceability/common/support/KeycloakSupport.groovy
+++ b/src/integration/groovy/net/catenax/traceability/common/support/KeycloakSupport.groovy
@@ -1,3 +1,22 @@
+/********************************************************************************
+ * Copyright (c) 2021,2022 Contributors to the CatenaX (ng) GitHub Organisation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 package net.catenax.traceability.common.support
 
 import net.catenax.traceability.common.security.KeycloakRole

--- a/src/integration/groovy/net/catenax/traceability/common/support/MailboxSupport.groovy
+++ b/src/integration/groovy/net/catenax/traceability/common/support/MailboxSupport.groovy
@@ -1,3 +1,22 @@
+/********************************************************************************
+ * Copyright (c) 2021,2022 Contributors to the CatenaX (ng) GitHub Organisation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 package net.catenax.traceability.common.support
 
 import com.icegreen.greenmail.spring.GreenMailBean

--- a/src/integration/groovy/net/catenax/traceability/common/support/RestitoProvider.groovy
+++ b/src/integration/groovy/net/catenax/traceability/common/support/RestitoProvider.groovy
@@ -1,3 +1,22 @@
+/********************************************************************************
+ * Copyright (c) 2021,2022 Contributors to the CatenaX (ng) GitHub Organisation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 package net.catenax.traceability.common.support
 
 import com.xebialabs.restito.server.StubServer

--- a/src/integration/resources/application-integration.yml
+++ b/src/integration/resources/application-integration.yml
@@ -1,3 +1,22 @@
+################################################################################
+# Copyright (c) 2021,2022 Contributors to the CatenaX (ng) GitHub Organisation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+################################################################################
+
 spring:
   security:
     oauth2:

--- a/src/main/java/net/catenax/traceability/TraceabilityApplication.java
+++ b/src/main/java/net/catenax/traceability/TraceabilityApplication.java
@@ -1,3 +1,22 @@
+/********************************************************************************
+ * Copyright (c) 2021,2022 Contributors to the CatenaX (ng) GitHub Organisation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 package net.catenax.traceability;
 
 import org.springframework.boot.SpringApplication;

--- a/src/main/java/net/catenax/traceability/assets/domain/Asset.java
+++ b/src/main/java/net/catenax/traceability/assets/domain/Asset.java
@@ -1,3 +1,22 @@
+/********************************************************************************
+ * Copyright (c) 2021,2022 Contributors to the CatenaX (ng) GitHub Organisation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 package net.catenax.traceability.assets.domain;
 
 import com.fasterxml.jackson.annotation.JsonFormat;

--- a/src/main/java/net/catenax/traceability/assets/domain/AssetNotFoundException.java
+++ b/src/main/java/net/catenax/traceability/assets/domain/AssetNotFoundException.java
@@ -1,3 +1,22 @@
+/********************************************************************************
+ * Copyright (c) 2021,2022 Contributors to the CatenaX (ng) GitHub Organisation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 package net.catenax.traceability.assets.domain;
 
 public class AssetNotFoundException extends RuntimeException {

--- a/src/main/java/net/catenax/traceability/assets/domain/AssetRepository.java
+++ b/src/main/java/net/catenax/traceability/assets/domain/AssetRepository.java
@@ -1,3 +1,22 @@
+/********************************************************************************
+ * Copyright (c) 2021,2022 Contributors to the CatenaX (ng) GitHub Organisation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 package net.catenax.traceability.assets.domain;
 
 import org.springframework.data.domain.Pageable;

--- a/src/main/java/net/catenax/traceability/assets/domain/AssetService.java
+++ b/src/main/java/net/catenax/traceability/assets/domain/AssetService.java
@@ -1,3 +1,22 @@
+/********************************************************************************
+ * Copyright (c) 2021,2022 Contributors to the CatenaX (ng) GitHub Organisation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 package net.catenax.traceability.assets.domain;
 
 import net.catenax.traceability.assets.infrastructure.adapters.openapi.irs.IrsService;

--- a/src/main/java/net/catenax/traceability/assets/domain/AssetsConverter.java
+++ b/src/main/java/net/catenax/traceability/assets/domain/AssetsConverter.java
@@ -1,3 +1,22 @@
+/********************************************************************************
+ * Copyright (c) 2021,2022 Contributors to the CatenaX (ng) GitHub Organisation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 package net.catenax.traceability.assets.domain;
 
 import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;

--- a/src/main/java/net/catenax/traceability/assets/domain/BpnRepository.java
+++ b/src/main/java/net/catenax/traceability/assets/domain/BpnRepository.java
@@ -1,3 +1,22 @@
+/********************************************************************************
+ * Copyright (c) 2021,2022 Contributors to the CatenaX (ng) GitHub Organisation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 package net.catenax.traceability.assets.domain;
 
 import java.util.Optional;

--- a/src/main/java/net/catenax/traceability/assets/domain/Dashboard.java
+++ b/src/main/java/net/catenax/traceability/assets/domain/Dashboard.java
@@ -1,3 +1,22 @@
+/********************************************************************************
+ * Copyright (c) 2021,2022 Contributors to the CatenaX (ng) GitHub Organisation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 package net.catenax.traceability.assets.domain;
 
 public record Dashboard(Long myItems, Long branchItems) {

--- a/src/main/java/net/catenax/traceability/assets/domain/DashboardService.java
+++ b/src/main/java/net/catenax/traceability/assets/domain/DashboardService.java
@@ -1,3 +1,22 @@
+/********************************************************************************
+ * Copyright (c) 2021,2022 Contributors to the CatenaX (ng) GitHub Organisation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 package net.catenax.traceability.assets.domain;
 
 import net.catenax.traceability.common.security.KeycloakAuthentication;

--- a/src/main/java/net/catenax/traceability/assets/domain/PageResult.java
+++ b/src/main/java/net/catenax/traceability/assets/domain/PageResult.java
@@ -1,3 +1,22 @@
+/********************************************************************************
+ * Copyright (c) 2021,2022 Contributors to the CatenaX (ng) GitHub Organisation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 package net.catenax.traceability.assets.domain;
 
 import org.springframework.beans.support.PagedListHolder;

--- a/src/main/java/net/catenax/traceability/assets/domain/QualityType.java
+++ b/src/main/java/net/catenax/traceability/assets/domain/QualityType.java
@@ -1,3 +1,22 @@
+/********************************************************************************
+ * Copyright (c) 2021,2022 Contributors to the CatenaX (ng) GitHub Organisation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 package net.catenax.traceability.assets.domain;
 
 import com.fasterxml.jackson.annotation.JsonValue;

--- a/src/main/java/net/catenax/traceability/assets/infrastructure/adapters/cache/bpn/BpnCache.java
+++ b/src/main/java/net/catenax/traceability/assets/infrastructure/adapters/cache/bpn/BpnCache.java
@@ -1,3 +1,22 @@
+/********************************************************************************
+ * Copyright (c) 2021,2022 Contributors to the CatenaX (ng) GitHub Organisation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 package net.catenax.traceability.assets.infrastructure.adapters.cache.bpn;
 
 import java.util.Optional;

--- a/src/main/java/net/catenax/traceability/assets/infrastructure/adapters/cache/bpn/BpnCaffeineCache.java
+++ b/src/main/java/net/catenax/traceability/assets/infrastructure/adapters/cache/bpn/BpnCaffeineCache.java
@@ -1,3 +1,22 @@
+/********************************************************************************
+ * Copyright (c) 2021,2022 Contributors to the CatenaX (ng) GitHub Organisation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 package net.catenax.traceability.assets.infrastructure.adapters.cache.bpn;
 
 import net.catenax.traceability.assets.infrastructure.config.cache.BpnCacheProperties;

--- a/src/main/java/net/catenax/traceability/assets/infrastructure/adapters/cache/bpn/BpnMapping.java
+++ b/src/main/java/net/catenax/traceability/assets/infrastructure/adapters/cache/bpn/BpnMapping.java
@@ -1,3 +1,22 @@
+/********************************************************************************
+ * Copyright (c) 2021,2022 Contributors to the CatenaX (ng) GitHub Organisation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 package net.catenax.traceability.assets.infrastructure.adapters.cache.bpn;
 
 public record BpnMapping(String bpn, String companyName) {

--- a/src/main/java/net/catenax/traceability/assets/infrastructure/adapters/email/EmailService.java
+++ b/src/main/java/net/catenax/traceability/assets/infrastructure/adapters/email/EmailService.java
@@ -1,3 +1,22 @@
+/********************************************************************************
+ * Copyright (c) 2021,2022 Contributors to the CatenaX (ng) GitHub Organisation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 package net.catenax.traceability.assets.infrastructure.adapters.email;
 
 import org.springframework.beans.factory.annotation.Value;

--- a/src/main/java/net/catenax/traceability/assets/infrastructure/adapters/mockdata/InMemoryAssetsRepository.java
+++ b/src/main/java/net/catenax/traceability/assets/infrastructure/adapters/mockdata/InMemoryAssetsRepository.java
@@ -1,3 +1,22 @@
+/********************************************************************************
+ * Copyright (c) 2021,2022 Contributors to the CatenaX (ng) GitHub Organisation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 package net.catenax.traceability.assets.infrastructure.adapters.mockdata;
 
 import net.catenax.traceability.assets.domain.Asset;

--- a/src/main/java/net/catenax/traceability/assets/infrastructure/adapters/openapi/bpn/BpnApiClient.java
+++ b/src/main/java/net/catenax/traceability/assets/infrastructure/adapters/openapi/bpn/BpnApiClient.java
@@ -1,3 +1,22 @@
+/********************************************************************************
+ * Copyright (c) 2021,2022 Contributors to the CatenaX (ng) GitHub Organisation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 package net.catenax.traceability.assets.infrastructure.adapters.openapi.bpn;
 
 import net.catenax.traceability.assets.infrastructure.config.openapi.CatenaApiConfig;

--- a/src/main/java/net/catenax/traceability/assets/infrastructure/adapters/openapi/bpn/BpnService.java
+++ b/src/main/java/net/catenax/traceability/assets/infrastructure/adapters/openapi/bpn/BpnService.java
@@ -1,3 +1,22 @@
+/********************************************************************************
+ * Copyright (c) 2021,2022 Contributors to the CatenaX (ng) GitHub Organisation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 package net.catenax.traceability.assets.infrastructure.adapters.openapi.bpn;
 
 import feign.FeignException;

--- a/src/main/java/net/catenax/traceability/assets/infrastructure/adapters/openapi/irs/IRSApiClient.java
+++ b/src/main/java/net/catenax/traceability/assets/infrastructure/adapters/openapi/irs/IRSApiClient.java
@@ -1,3 +1,22 @@
+/********************************************************************************
+ * Copyright (c) 2021,2022 Contributors to the CatenaX (ng) GitHub Organisation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 package net.catenax.traceability.assets.infrastructure.adapters.openapi.irs;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/src/main/java/net/catenax/traceability/assets/infrastructure/adapters/openapi/irs/IrsService.java
+++ b/src/main/java/net/catenax/traceability/assets/infrastructure/adapters/openapi/irs/IrsService.java
@@ -1,3 +1,22 @@
+/********************************************************************************
+ * Copyright (c) 2021,2022 Contributors to the CatenaX (ng) GitHub Organisation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 package net.catenax.traceability.assets.infrastructure.adapters.openapi.irs;
 
 import net.catenax.traceability.assets.domain.Asset;

--- a/src/main/java/net/catenax/traceability/assets/infrastructure/adapters/openapi/irs/JobRunning.java
+++ b/src/main/java/net/catenax/traceability/assets/infrastructure/adapters/openapi/irs/JobRunning.java
@@ -1,3 +1,22 @@
+/********************************************************************************
+ * Copyright (c) 2021,2022 Contributors to the CatenaX (ng) GitHub Organisation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 package net.catenax.traceability.assets.infrastructure.adapters.openapi.irs;
 
 import net.catenax.traceability.assets.infrastructure.adapters.openapi.irs.IRSApiClient.JobResponse;

--- a/src/main/java/net/catenax/traceability/assets/infrastructure/adapters/rest/assets/AssetsController.java
+++ b/src/main/java/net/catenax/traceability/assets/infrastructure/adapters/rest/assets/AssetsController.java
@@ -1,3 +1,22 @@
+/********************************************************************************
+ * Copyright (c) 2021,2022 Contributors to the CatenaX (ng) GitHub Organisation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 package net.catenax.traceability.assets.infrastructure.adapters.rest.assets;
 
 import net.catenax.traceability.assets.domain.Asset;

--- a/src/main/java/net/catenax/traceability/assets/infrastructure/adapters/rest/assets/UpdateAsset.java
+++ b/src/main/java/net/catenax/traceability/assets/infrastructure/adapters/rest/assets/UpdateAsset.java
@@ -1,3 +1,22 @@
+/********************************************************************************
+ * Copyright (c) 2021,2022 Contributors to the CatenaX (ng) GitHub Organisation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 package net.catenax.traceability.assets.infrastructure.adapters.rest.assets;
 
 import net.catenax.traceability.assets.domain.QualityType;

--- a/src/main/java/net/catenax/traceability/assets/infrastructure/adapters/rest/dashboard/DashboardController.java
+++ b/src/main/java/net/catenax/traceability/assets/infrastructure/adapters/rest/dashboard/DashboardController.java
@@ -1,3 +1,22 @@
+/********************************************************************************
+ * Copyright (c) 2021,2022 Contributors to the CatenaX (ng) GitHub Organisation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 package net.catenax.traceability.assets.infrastructure.adapters.rest.dashboard;
 
 import net.catenax.traceability.assets.domain.Dashboard;

--- a/src/main/java/net/catenax/traceability/assets/infrastructure/config/cache/BpnCacheConfig.java
+++ b/src/main/java/net/catenax/traceability/assets/infrastructure/config/cache/BpnCacheConfig.java
@@ -1,3 +1,22 @@
+/********************************************************************************
+ * Copyright (c) 2021,2022 Contributors to the CatenaX (ng) GitHub Organisation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 package net.catenax.traceability.assets.infrastructure.config.cache;
 
 import com.github.benmanes.caffeine.cache.Caffeine;

--- a/src/main/java/net/catenax/traceability/assets/infrastructure/config/cache/BpnCacheProperties.java
+++ b/src/main/java/net/catenax/traceability/assets/infrastructure/config/cache/BpnCacheProperties.java
@@ -1,3 +1,22 @@
+/********************************************************************************
+ * Copyright (c) 2021,2022 Contributors to the CatenaX (ng) GitHub Organisation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 package net.catenax.traceability.assets.infrastructure.config.cache;
 
 import net.catenax.traceability.common.properties.CacheProperties;

--- a/src/main/java/net/catenax/traceability/assets/infrastructure/config/openapi/CatenaApiConfig.java
+++ b/src/main/java/net/catenax/traceability/assets/infrastructure/config/openapi/CatenaApiConfig.java
@@ -1,3 +1,22 @@
+/********************************************************************************
+ * Copyright (c) 2021,2022 Contributors to the CatenaX (ng) GitHub Organisation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 package net.catenax.traceability.assets.infrastructure.config.openapi;
 
 import feign.RequestInterceptor;

--- a/src/main/java/net/catenax/traceability/assets/infrastructure/config/openapi/bpn/BpnApiProperties.java
+++ b/src/main/java/net/catenax/traceability/assets/infrastructure/config/openapi/bpn/BpnApiProperties.java
@@ -1,3 +1,22 @@
+/********************************************************************************
+ * Copyright (c) 2021,2022 Contributors to the CatenaX (ng) GitHub Organisation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 package net.catenax.traceability.assets.infrastructure.config.openapi.bpn;
 
 import net.catenax.traceability.common.properties.FeignProperties;

--- a/src/main/java/net/catenax/traceability/assets/infrastructure/config/openapi/bpn/KeycloakAuthorizationInterceptor.java
+++ b/src/main/java/net/catenax/traceability/assets/infrastructure/config/openapi/bpn/KeycloakAuthorizationInterceptor.java
@@ -1,3 +1,22 @@
+/********************************************************************************
+ * Copyright (c) 2021,2022 Contributors to the CatenaX (ng) GitHub Organisation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 package net.catenax.traceability.assets.infrastructure.config.openapi.bpn;
 
 import feign.RequestInterceptor;

--- a/src/main/java/net/catenax/traceability/assets/infrastructure/config/openapi/bpn/KeycloakTechnicalUserAuthorizationException.java
+++ b/src/main/java/net/catenax/traceability/assets/infrastructure/config/openapi/bpn/KeycloakTechnicalUserAuthorizationException.java
@@ -1,3 +1,22 @@
+/********************************************************************************
+ * Copyright (c) 2021,2022 Contributors to the CatenaX (ng) GitHub Organisation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 package net.catenax.traceability.assets.infrastructure.config.openapi.bpn;
 
 public class KeycloakTechnicalUserAuthorizationException extends RuntimeException {

--- a/src/main/java/net/catenax/traceability/common/config/ApplicationConfig.java
+++ b/src/main/java/net/catenax/traceability/common/config/ApplicationConfig.java
@@ -1,3 +1,22 @@
+/********************************************************************************
+ * Copyright (c) 2021,2022 Contributors to the CatenaX (ng) GitHub Organisation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 package net.catenax.traceability.common.config;
 
 import net.catenax.traceability.common.docs.SwaggerPageable;

--- a/src/main/java/net/catenax/traceability/common/config/ErrorHandlingConfig.java
+++ b/src/main/java/net/catenax/traceability/common/config/ErrorHandlingConfig.java
@@ -1,3 +1,22 @@
+/********************************************************************************
+ * Copyright (c) 2021,2022 Contributors to the CatenaX (ng) GitHub Organisation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 package net.catenax.traceability.common.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/src/main/java/net/catenax/traceability/common/config/FeignGlobalConfig.java
+++ b/src/main/java/net/catenax/traceability/common/config/FeignGlobalConfig.java
@@ -1,3 +1,22 @@
+/********************************************************************************
+ * Copyright (c) 2021,2022 Contributors to the CatenaX (ng) GitHub Organisation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 package net.catenax.traceability.common.config;
 
 import feign.Contract;

--- a/src/main/java/net/catenax/traceability/common/config/SchedulerConfig.java
+++ b/src/main/java/net/catenax/traceability/common/config/SchedulerConfig.java
@@ -1,3 +1,22 @@
+/********************************************************************************
+ * Copyright (c) 2021,2022 Contributors to the CatenaX (ng) GitHub Organisation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 package net.catenax.traceability.common.config;
 
 import net.catenax.traceability.assets.domain.AssetService;

--- a/src/main/java/net/catenax/traceability/common/config/SecurityConfig.java
+++ b/src/main/java/net/catenax/traceability/common/config/SecurityConfig.java
@@ -1,3 +1,22 @@
+/********************************************************************************
+ * Copyright (c) 2021,2022 Contributors to the CatenaX (ng) GitHub Organisation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 package net.catenax.traceability.common.config;
 
 import org.keycloak.adapters.springsecurity.KeycloakConfiguration;

--- a/src/main/java/net/catenax/traceability/common/config/WebConfig.java
+++ b/src/main/java/net/catenax/traceability/common/config/WebConfig.java
@@ -1,3 +1,22 @@
+/********************************************************************************
+ * Copyright (c) 2021,2022 Contributors to the CatenaX (ng) GitHub Organisation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 package net.catenax.traceability.common.config;
 
 import net.catenax.traceability.common.security.InjectedKeycloakAuthenticationHandler;

--- a/src/main/java/net/catenax/traceability/common/docs/DocumentationPlugin.java
+++ b/src/main/java/net/catenax/traceability/common/docs/DocumentationPlugin.java
@@ -1,3 +1,22 @@
+/********************************************************************************
+ * Copyright (c) 2021,2022 Contributors to the CatenaX (ng) GitHub Organisation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 package net.catenax.traceability.common.docs;
 
 import org.springframework.core.annotation.Order;

--- a/src/main/java/net/catenax/traceability/common/docs/SwaggerPageable.java
+++ b/src/main/java/net/catenax/traceability/common/docs/SwaggerPageable.java
@@ -1,3 +1,22 @@
+/********************************************************************************
+ * Copyright (c) 2021,2022 Contributors to the CatenaX (ng) GitHub Organisation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 package net.catenax.traceability.common.docs;
 
 import io.swagger.annotations.ApiParam;

--- a/src/main/java/net/catenax/traceability/common/properties/CacheProperties.java
+++ b/src/main/java/net/catenax/traceability/common/properties/CacheProperties.java
@@ -1,3 +1,22 @@
+/********************************************************************************
+ * Copyright (c) 2021,2022 Contributors to the CatenaX (ng) GitHub Organisation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 package net.catenax.traceability.common.properties;
 
 import java.time.Duration;

--- a/src/main/java/net/catenax/traceability/common/properties/FeignProperties.java
+++ b/src/main/java/net/catenax/traceability/common/properties/FeignProperties.java
@@ -1,3 +1,22 @@
+/********************************************************************************
+ * Copyright (c) 2021,2022 Contributors to the CatenaX (ng) GitHub Organisation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 package net.catenax.traceability.common.properties;
 
 public class FeignProperties {

--- a/src/main/java/net/catenax/traceability/common/security/InjectedKeycloakAuthentication.java
+++ b/src/main/java/net/catenax/traceability/common/security/InjectedKeycloakAuthentication.java
@@ -1,3 +1,22 @@
+/********************************************************************************
+ * Copyright (c) 2021,2022 Contributors to the CatenaX (ng) GitHub Organisation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 package net.catenax.traceability.common.security;
 
 import java.lang.annotation.ElementType;

--- a/src/main/java/net/catenax/traceability/common/security/InjectedKeycloakAuthenticationHandler.java
+++ b/src/main/java/net/catenax/traceability/common/security/InjectedKeycloakAuthenticationHandler.java
@@ -1,3 +1,22 @@
+/********************************************************************************
+ * Copyright (c) 2021,2022 Contributors to the CatenaX (ng) GitHub Organisation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 package net.catenax.traceability.common.security;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/net/catenax/traceability/common/security/KeycloakAuthentication.java
+++ b/src/main/java/net/catenax/traceability/common/security/KeycloakAuthentication.java
@@ -1,3 +1,22 @@
+/********************************************************************************
+ * Copyright (c) 2021,2022 Contributors to the CatenaX (ng) GitHub Organisation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 package net.catenax.traceability.common.security;
 
 import java.util.Arrays;

--- a/src/main/java/net/catenax/traceability/common/security/KeycloakRole.java
+++ b/src/main/java/net/catenax/traceability/common/security/KeycloakRole.java
@@ -1,3 +1,22 @@
+/********************************************************************************
+ * Copyright (c) 2021,2022 Contributors to the CatenaX (ng) GitHub Organisation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 package net.catenax.traceability.common.security;
 
 import java.util.Arrays;

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,3 +1,22 @@
+################################################################################
+# Copyright (c) 2021,2022 Contributors to the CatenaX (ng) GitHub Organisation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+################################################################################
+
 spring:
   security:
     oauth2:

--- a/src/main/resources/application-int.yml
+++ b/src/main/resources/application-int.yml
@@ -1,3 +1,22 @@
+################################################################################
+# Copyright (c) 2021,2022 Contributors to the CatenaX (ng) GitHub Organisation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+################################################################################
+
 spring:
   security:
     oauth2:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,22 @@
+################################################################################
+# Copyright (c) 2021,2022 Contributors to the CatenaX (ng) GitHub Organisation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+################################################################################
+
 server:
   servlet:
     context-path: /api

--- a/src/main/resources/mail-templates/basic.html
+++ b/src/main/resources/mail-templates/basic.html
@@ -1,3 +1,22 @@
+<!--
+Copyright (c) 2021,2022 Contributors to the CatenaX (ng) GitHub Organisation
+
+See the NOTICE file(s) distributed with this work for additional
+information regarding copyright ownership.
+
+This program and the accompanying materials are made available under the
+terms of the Apache License, Version 2.0 which is available at
+https://www.apache.org/licenses/LICENSE-2.0.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations
+under the License.
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 <!doctype html>
 <html>
 <head><!-- Yahoo App Android will strip this --></head>

--- a/src/main/resources/swagger.yml
+++ b/src/main/resources/swagger.yml
@@ -1,3 +1,22 @@
+################################################################################
+# Copyright (c) 2021,2022 Contributors to the CatenaX (ng) GitHub Organisation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+################################################################################
+
 components:
   securitySchemes:
     bearerAuth:

--- a/src/test/groovy/net/catenax/traceability/UnitSpec.groovy
+++ b/src/test/groovy/net/catenax/traceability/UnitSpec.groovy
@@ -1,3 +1,22 @@
+/********************************************************************************
+ * Copyright (c) 2021,2022 Contributors to the CatenaX (ng) GitHub Organisation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 package net.catenax.traceability
 
 import spock.lang.Specification

--- a/src/test/groovy/net/catenax/traceability/assets/domain/AssetServiceSpec.groovy
+++ b/src/test/groovy/net/catenax/traceability/assets/domain/AssetServiceSpec.groovy
@@ -1,3 +1,22 @@
+/********************************************************************************
+ * Copyright (c) 2021,2022 Contributors to the CatenaX (ng) GitHub Organisation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 package net.catenax.traceability.assets.domain
 
 import net.catenax.traceability.UnitSpec


### PR DESCRIPTION
License template taken from https://github.com/catenax-ng/foss-example/blob/main/catenax-ng-repositories/CopyrightAndLicenseHeader_1.txt

I've also committed the script which add header. In order to use Node.js 16 should be installed and it can be run by:

```
node ./scripts/add-license-header.js --src=./src  
```