### PR TITLE
TRACEFOSS-560 Create helm chart releases only for release tags

### DIFF
--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -3,8 +3,6 @@ name: Release Charts
 on:
   workflow_dispatch:
   push:
-    branches:
-      - main
     tags:
       - 'v*'
 
@@ -40,3 +38,4 @@ jobs:
         uses: helm/chart-releaser-action@v1.4.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          CR_RELEASE_NAME_TEMPLATE: "trace-x-backend-helm-charts-{{ .Version }}"


### PR DESCRIPTION
They also get a release name distinct from the releases for the software.