### PR TITLE
change: use SONAR_PROJECT_KEY and SONAR_ORGANIZATION env vars in build

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,9 +37,9 @@ repositories {
 
 sonarqube {
 	properties {
-		property("sonar.organization", "catenax-ng")
+		property("sonar.organization", System.getenv("SONAR_ORGANIZATION") ?: "catenax-ng")
 		property("sonar.host.url", "https://sonarcloud.io")
-		property("sonar.projectKey", "catenax-ng_product-traceability-foss-backend")
+		property("sonar.projectKey", System.getenv("SONAR_PROJECT_KEY") ?: "catenax-ng_product-traceability-foss-backend")
 		property("sonar.coverage.jacoco.xmlReportPaths", "${project.buildDir}/jacoco/*.xml")
 		property(
 			"sonar.cpd.exclusions", listOf(


### PR DESCRIPTION
The new repos will have these vars set. For now the build falls back to the previous values, if the variables are not set.